### PR TITLE
Add render_readme: true

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -4,5 +4,6 @@
   "domains": [
     "remote"
   ],
+  "render_readme": true,
   "homeassistant": "0.106.0"
 }


### PR DESCRIPTION
According to the docs https://hacs.xyz/docs/publish/start#hacsjson

This can be used instead of providing a info.md file which in this case would be much of the same. 

Should make the CI pass on: https://github.com/hacs/default/pull/275